### PR TITLE
Skip zip/tar by passing correct flag, rather by removing it after the build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -107,10 +107,7 @@ echo "Building the '$1' preset..."
 
 JAVA_ARGS=${ARGS// -t / } # Remove -t from arrgs
 
-java -jar ckbuilder/$CKBUILDER_VERSION/ckbuilder.jar --build ckeditor $target $skip --version="$CKEDITOR_VERSION ($name)" --revision $rev --build-config presets/$1-build-config.js --overwrite $JAVA_ARGS
-
-rm $target/*.gz
-rm $target/*.zip
+java -jar ckbuilder/$CKBUILDER_VERSION/ckbuilder.jar --build ckeditor $target $skip --version="$CKEDITOR_VERSION ($name)" --revision $rev --build-config presets/$1-build-config.js --no-zip --no-tar --overwrite $JAVA_ARGS
 
 cp presets/$1-ckeditor-config.js $target/ckeditor/config.js
 cp presets/README.md $target/ckeditor/


### PR DESCRIPTION
`ckbuilder.jar` exposes --no-zip and --no-tar command line arguments.

This will shave a couple seconds for each build.