### PR TITLE
Fixed incorrect path to MathJax library

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -134,7 +134,7 @@ if [[ "$ARGS" == *\ \-t\ * ]]; then
 		mkdir $target/ckeditor/tests/plugins/mathjax/_assets
 		cp -r "$MATHJAX_LIB_PATH" $target/ckeditor/tests/plugins/mathjax/_assets/mathjax
 		echo "" >> $target/ckeditor/bender.js
-		echo "config.mathJaxLibPath = '_assets/mathjax/MathJax.js?config=TeX-AMS_HTML';" >> $target/ckeditor/bender.js
+		echo "config.mathJaxLibPath = '/tests/plugins/mathjax/_assets/mathjax/MathJax.js?config=TeX-AMS_HTML';" >> $target/ckeditor/bender.js
 	else
 		echo "WARNING: No MathJax lib in $MATHJAX_LIB_PATH." >&2
 	fi


### PR DESCRIPTION
MathJax is copied into `_assets` subdirectory of `mathjax` plugin's tests, however a path inserted into `bender.js` file assumes that it's located inside the main `_assets` directory, causing an error.