### PR TITLE
Enable uploadimage

### DIFF
--- a/presets/full-build-config.js
+++ b/presets/full-build-config.js
@@ -90,6 +90,7 @@ var CKBUILDER_CONFIG = {
 		templates: 1,
 		toolbar: 1,
 		undo: 1,
+		uploadimage: 1,
 		wsc: 1,
 		wysiwygarea: 1
 	}

--- a/presets/standard-build-config.js
+++ b/presets/standard-build-config.js
@@ -66,6 +66,7 @@ var CKBUILDER_CONFIG = {
 		tabletools: 1,
 		toolbar: 1,
 		undo: 1,
+		uploadimage: 1,
 		wsc: 1,
 		wysiwygarea: 1
 	}


### PR DESCRIPTION
Enable `uploadimage` plugin in `standard` and `full` presets. Closes #14.